### PR TITLE
Updating renamer package to address deep-extend vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "karma-jasmine-html-reporter": "^0.2.2",
     "npm-run-all": "^4.1.2",
     "protractor": "^5.2.1",
-    "renamer": "^0.6.1",
+    "renamer": "^1.1.0",
     "rimraf": "^2.6.2",
     "rollup": "^0.52.1",
     "ts-node": "^4.0.1",


### PR DESCRIPTION
Not sure if I did this right. npm audit traced the vulnerability to renamer so I updated that package, ran npm install and that seemed to fix the vulnerability.  However it also changed a bunch of other dependencies in the lock file from a static number to a greater version than <some lower version number x>.  Not sure if I need to then manually edit all of those version numbers?